### PR TITLE
Screen sharing from a iframe with different origin

### DIFF
--- a/chrome/ScreenSharing/background-script.js
+++ b/chrome/ScreenSharing/background-script.js
@@ -12,8 +12,19 @@ chrome.runtime.onConnect.addListener(function (port) {
   });
 
   function getSourceID(requestId) {
-    chrome.desktopCapture.chooseDesktopMedia(session, port.sender.tab, function(sourceId) {
-      console.log('sourceId', sourceId);
+    
+	// as related in https://code.google.com/p/chromium/issues/detail?id=413602 and https://code.google.com/p/chromium/issues/detail?id=425344 :
+	// a frame/iframe requesting screen sharing from a different origin than the parent window
+	// will receive the InvalidStateError when using the getUserMedia function.
+	// the solution its to change the tab.url property to the same as of the requesting iframe. Its works without iframe as well.
+	// requires Chrome 40+
+	
+	var tab = port.sender.tab;
+	tab.url = port.sender.url;
+	
+	chrome.desktopCapture.chooseDesktopMedia(session, tab, function(sourceId) {
+      
+	  console.log('sourceId', sourceId);
             
       // "sourceId" will be empty if permission is denied
       if(!sourceId || !sourceId.length) {


### PR DESCRIPTION
as related in https://code.google.com/p/chromium/issues/detail?id=413602 and https://code.google.com/p/chromium/issues/detail?id=425344 :

a frame/iframe requesting screen sharing from a different origin than the parent window will receive the InvalidStateError when using the getUserMedia function. The solution its to change the tab.url property to the same as of the requesting iframe when calling desktopCapture.chooseDesktopMedia. Its works without iframe as well.

Requires Chrome 40+
