### PR TITLE
Allow multiple screen-sharing domains in Firefox extension.

### DIFF
--- a/firefox/ScreenSharing/bootstrap.js
+++ b/firefox/ScreenSharing/bootstrap.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var gDomain = '*.example.com';
+var gDomains = ['*.example.com'];
 var allowDomainsPrefKey = 'media.getusermedia.screensharing.allowed_domains';
 
 function startup(aData, aReason) {
@@ -9,23 +9,26 @@ function startup(aData, aReason) {
   }
   var prefs = Components.classes['@mozilla.org/preferences-service;1']
       .getService(Components.interfaces.nsIPrefBranch);
-  var curPref = prefs.getCharPref(allowDomainsPrefKey);
-  if (curPref.contains(gDomain)) {
-    return;
-  }
-  prefs.setCharPref(allowDomainsPrefKey, curPref + ',' + gDomain);
+  gDomains.forEach(function(domain){
+    var curPref = prefs.getCharPref(allowDomainsPrefKey);
+    if (curPref.contains(domain)) {
+      return;
+    }
+    prefs.setCharPref(allowDomainsPrefKey, curPref + ',' + domain);
+  });
 }
 
 function shutdown(aData, aReason) {
   if (aReason == APP_SHUTDOWN) {
     return;
   }
-
   var prefs = Components.classes['@mozilla.org/preferences-service;1']
                .getService(Components.interfaces.nsIPrefBranch);
-  var curPref = prefs.getCharPref(allowDomainsPrefKey);
-  var newPref = curPref.split(',').filter((pref) => pref.trim() != gDomain).join(',');
-  prefs.setCharPref(allowDomainsPrefKey, newPref);
+  gDomains.forEach(function(domain){
+    var curPref = prefs.getCharPref(allowDomainsPrefKey);
+    var newPref = curPref.split(',').filter((pref) => pref.trim() != domain).join(',');
+    prefs.setCharPref(allowDomainsPrefKey, newPref);    
+  });
 }
 
 function install(aData, aReason) {}


### PR DESCRIPTION
Change bootstrap.js to use an array of domains rather than a single string. Matches Chrome screen-sharing extension allowing array of multiple screen-sharing domains.
