### PR TITLE
Corrections for v2 of the Firefox screen-sharing extension.

### DIFF
--- a/firefox/README.md
+++ b/firefox/README.md
@@ -28,17 +28,30 @@ enter the following:
 
    Change the values for following fields:
 
-   * `id` -- The unique ID for the extension. See [this documentation][package-json-id].
+   * `id` -- The unique ID for the extension. See [this documentation][package-json].
    * `title` -- The name of the extension, to be displayed in the Firefox UI.
    * `description` -- The description of the extension, to be displayed in the
      Firefox UI.
    * `version` -- The version.
-   * `creator` -- The name of the creator, to be displayed in the Firefox UI.
+   * `author` -- The name of the creator, to be displayed in the Firefox UI.
 
-   See the Mozilla [Add-on package.json documenation][package-json].
+   See the Mozilla [Add-on package.json documentation][package-json].
 
 3. Edit the index.js file. Set the `gDomain` property to match the domain(s)
-   your screen-sharing extension supports.
+   your screen-sharing extension supports. Set this to an array of one or more strings.
+
+   Use an asterisk at the beginning of the string to match multiple subdomains. For example,
+   the following `gDomain` values match pages at `https://example.com/bar` and
+   `https://foo.example.com/bar`:
+
+       ['*.example.com']
+       ['*.example.com', '*.another-domain.com']
+
+   Omit the asterisk at the beginning of the string to match a specific subdomain. For example,
+   the following `gDomain` values match `https://foo.example.com/bar` but not `https://example.com/bar`:
+
+       ['foo.example.com']
+       ['foo.example.com', '*.another-domain.com']
 
 4. In the terminal, navigate to the firefox/ScreenSharing directory. Then package the extension
    by running the following on the command line:
@@ -110,18 +123,6 @@ Install your extension in one of these ways:
 
 * [add-on-sdk][add-on-sdk] -- Mozilla add-on SDK documentation.
 
-[ot]: http://tokbox.com/opentok/libraries/client/js/
-[whitelist]: https://wiki.mozilla.org/Screensharing
-[npm]: https://nodejs.org/en/download/
-[jpm]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/jpm
-[package-json]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/package_json
-[package-json-id]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/package_json#id
-[add-on-sdk]: https://addons.mozilla.org/en-US/developers/docs/sdk/latest
-[add-ons]: https://addons.mozilla.org/en-US/firefox/extensions/
-[add-on-sdk]: https://developer.mozilla.org/en-US/Add-ons/SDK
-[mozilla-add-on-hub]: https://addons.mozilla.org/en-US/developers/
-[extension-signing]: https://wiki.mozilla.org/Add-ons/Extension_Signing
-
 ## Using the extension with OpenTok.js
 
 To publish a screen:
@@ -148,6 +149,16 @@ var publisher = OT.initPublisher('target-element-id', {
 
 See the [OpenTok.js screen-sharing documentation][ot-screensharing].
 
+[ot]: http://tokbox.com/opentok/libraries/client/js/
+[whitelist]: https://wiki.mozilla.org/Screensharing
+[npm]: https://nodejs.org/en/download/
+[jpm]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/jpm
+[package-json]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/package_json
+[add-on-sdk]: https://addons.mozilla.org/en-US/developers/docs/sdk/latest
+[add-ons]: https://addons.mozilla.org/en-US/firefox/extensions/
+[add-on-sdk]: https://developer.mozilla.org/en-US/Add-ons/SDK
+[mozilla-add-on-hub]: https://addons.mozilla.org/en-US/developers/
+[extension-signing]: https://wiki.mozilla.org/Add-ons/Extension_Signing
 [ot-screensharing]: https://tokbox.com/opentok/tutorials/screen-sharing/js/
 
 ## License

--- a/firefox/README.md
+++ b/firefox/README.md
@@ -53,6 +53,9 @@ enter the following:
        ['foo.example.com']
        ['foo.example.com', '*.another-domain.com']
 
+   Do _not_ include the protocol, `'https://'`, in the `gDomain` strings. And do _not_ include an
+   asterisk before a _subdomain_ (as in `['*.foo.example.com’]`).
+
 4. In the terminal, navigate to the firefox/ScreenSharing directory. Then package the extension
    by running the following on the command line:
 

--- a/firefox/ScreenSharing/index.js
+++ b/firefox/ScreenSharing/index.js
@@ -5,7 +5,7 @@ var gDomains = ['*.example.com'];
 
 exports.main = function (options) {
 
-  if (options.loadReason === 'install' || options.loadReason === 'enable') {
+  if (options.loadReason !== 'startup') {
     var curPrefs = prefsService.get(allowDomainsPrefKey).replace(/\s/g, '').split(',');
 
     gDomains.forEach(function(domain){
@@ -19,7 +19,7 @@ exports.main = function (options) {
 };
 
 exports.onUnload = function (reason) {
-  if (reason === 'uninstall' || options.loadReason === 'disable') {
+  if (reason === 'uninstall' || reason === 'disable') {
     gDomains.forEach(function(domain){
       var curPref = prefsService.get(allowDomainsPrefKey);
       var newPref = curPref.split(',').filter((pref) => pref.trim() != domain).join(',');
@@ -30,6 +30,6 @@ exports.onUnload = function (reason) {
 };
 
 pageMod.PageMod({
-  include: gDomains,
+  include: gDomains.map(domain => domain[0] === '*' ? domain : `https://${domain}/*`),
   contentScript: 'unsafeWindow.OTScreenSharing = cloneInto({}, unsafeWindow);'
 });

--- a/firefox/ScreenSharing/package.json
+++ b/firefox/ScreenSharing/package.json
@@ -1,10 +1,10 @@
 {
+  "id": "ffscreensharing@example.com",
   "title": "Screen-sharing extension",
-  "name": "my-addon",
   "version": "0.0.1",
   "description": "A screen-sharing extension",
-  "main": "index.js",
   "author": "",
+  "main": "index.js",
   "engines": {
     "firefox": ">=38.0a1",
     "fennec": ">=38.0a1"


### PR DESCRIPTION
This change:
- Fixes issues in matching domains for the Firefox extension (and adds better docs on setting the matching domains)
- Fixes an issue in disabling the Firefox extension
- Cleans up some other minor docs issues
