### PR TITLE
Fix the screensharing-test html for IE

### DIFF
--- a/screensharing-test.html
+++ b/screensharing-test.html
@@ -11,7 +11,7 @@
     // Go to https://dashboard.tokbox.com/ to get your OpenTok API Key and to generate
     // a test session ID and token:
     var apiKey    = '',
-      sessionId = '';
+      sessionId = '',
       token     = '';
 
     // Replace this with the ID for your Chrome screen-sharing extension, which you can

--- a/screensharing-test.html
+++ b/screensharing-test.html
@@ -2,6 +2,7 @@
 <body>
   <button onclick="javascript:screenshare();" disabled id="shareBtn">Share your screen</button>
   <div id="camera-publisher"></div>
+  <div id="screen-publisher"></div>
   <div id="camera-subscriber"></div>
   <div id="screen-subscriber"></div>
   <script src="//static.opentok.com/v2/js/opentok.js"></script>
@@ -10,7 +11,7 @@
     // Go to https://dashboard.tokbox.com/ to get your OpenTok API Key and to generate
     // a test session ID and token:
     var apiKey    = '',
-      sessionId = '',
+      sessionId = '';
       token     = '';
 
     // Replace this with the ID for your Chrome screen-sharing extension, which you can
@@ -70,9 +71,8 @@
         } else {
           // Screen sharing is available. Publish the screen.
           // Create an element, but do not display it in the HTML DOM:
-          var screenContainerElement = document.createElement('div');
           var screenSharingPublisher = OT.initPublisher(
-            screenContainerElement,
+            'screen-publisher',
             { videoSource : 'screen' },
             function(error) {
               if (error) {


### PR DESCRIPTION
Making the screen sharing Publisher visible so that it works in IE. There is a known issue in IE where if the Publisher is not in the DOM then it does not work.
https://tokbox.com/developer/sdks/js/release-notes.html#knownIssues