### PR TITLE
Added 'tab' to desktop capture source types for Chrome extension

### DIFF
--- a/chrome/ScreenSharing/background-script.js
+++ b/chrome/ScreenSharing/background-script.js
@@ -1,7 +1,7 @@
 ﻿// this background script is used to invoke desktopCapture API
 // to capture screen-MediaStream.
 
-var session = ['screen', 'window'];
+var session = ['screen', 'window', 'tab'];
 
 function getSourceID(sender, callback) {
   // as related in https://code.google.com/p/chromium/issues/detail?id=413602 and https://code.google.com/p/chromium/issues/detail?id=425344 :


### PR DESCRIPTION
Based on chrome's docs https://developer.chrome.com/extensions/desktopCapture , the extension should be able to capture tab.