### PR TITLE
Updated Chrome readme with inline deprecation warning

### DIFF
--- a/chrome/ScreenSharing/README.md
+++ b/chrome/ScreenSharing/README.md
@@ -112,7 +112,7 @@ OT.checkScreenSharingCapability(function(response) {
 ```
 
 If you are using [Inline Installation][inline] their are additional APIs you can use.
-(Important: As of 06/12/2018, [inline installation is deprecated][inline-deprecated-faq].)
+(Important: As of June 12, 2018, [inline installation is deprecated][inline-deprecated-faq].)
 
 To publish a screen:
 

--- a/chrome/ScreenSharing/README.md
+++ b/chrome/ScreenSharing/README.md
@@ -7,7 +7,7 @@ This is a variation of [the extension][mkext] created by [Muaz Khan][mkgh] with 
 
 This is version 2 of the extension. With version 2, the client can use the extension immediately after installing it using the [Inline Installation][inline] method, without reloading the page. When calling the `OT.registerScreenSharingExtension()` method (see below), you must now pass in the version number, 2.
 
-(Important: As of 06/12/2018, [inline installation is deprecated][inline-deprecated-faq].)
+(Important: As of June 12, 2018, [inline installation is deprecated][inline-deprecated-faq].)
 
 ## Customizing the extension for your website
 
@@ -69,7 +69,7 @@ in the Chrome Web Store.
 See the [Chrome documentation on publishing your app][publish] for details on publishing your extension in the Chrome Web Store.
 
 You can use the [Chrome inline installation][inline] to initiate installation of your extension
-"inline" from your site. (Important: As of 06/12/2018, [inline installation is deprecated][inline-deprecated-faq].)
+"inline" from your site. (Important: As of June 12, 2018, [inline installation is deprecated][inline-deprecated-faq].)
 
 In your app, you need to register the ID of the extension using the
 <code>OT.registerScreenSharingExtension()</code> method (defined in the OpenTok.js library).

--- a/chrome/ScreenSharing/README.md
+++ b/chrome/ScreenSharing/README.md
@@ -5,7 +5,9 @@ This extension allows you to use the screen sharing support in Chrome with the [
 
 This is a variation of [the extension][mkext] created by [Muaz Khan][mkgh] with some tweaks to make it more suitable for use with the OpenTok API.
 
-This is version 2 of the extension. With version 2, the client can use the extension immediately after installing it using the inline installation method, without reloading the page. When calling the `OT.registerScreenSharingExtension()` method (see below), you must now pass in the version number, 2.
+This is version 2 of the extension. With version 2, the client can use the extension immediately after installing it using the [Inline Installation][inline] method, without reloading the page. When calling the `OT.registerScreenSharingExtension()` method (see below), you must now pass in the version number, 2.
+
+(Important: As of 06/12/2018, [inline installation is deprecated][inline-deprecated-faq].)
 
 ## Customizing the extension for your website
 
@@ -67,7 +69,7 @@ in the Chrome Web Store.
 See the [Chrome documentation on publishing your app][publish] for details on publishing your extension in the Chrome Web Store.
 
 You can use the [Chrome inline installation][inline] to initiate installation of your extension
-"inline" from your site.
+"inline" from your site. (Important: As of 06/12/2018, [inline installation is deprecated][inline-deprecated-faq].)
 
 In your app, you need to register the ID of the extension using the
 <code>OT.registerScreenSharingExtension()</code> method (defined in the OpenTok.js library).
@@ -75,6 +77,7 @@ In your app, you need to register the ID of the extension using the
 
 [publish]: https://developer.chrome.com/webstore/publish
 [inline]: https://developer.chrome.com/webstore/inline_installation
+[inline-deprecated-faq]: https://developer.chrome.com/extensions/inline_faq
 
 ## How to use with OpenTok.js?
 
@@ -109,6 +112,7 @@ OT.checkScreenSharingCapability(function(response) {
 ```
 
 If you are using [Inline Installation][inline] their are additional APIs you can use.
+(Important: As of 06/12/2018, [inline installation is deprecated][inline-deprecated-faq].)
 
 To publish a screen:
 


### PR DESCRIPTION
From the Chrome Inline-Installation Deprecation Migration FAQ: as of 06/12/2018, inline installation of Chrome Extensions is deprecated.