### PR TITLE
Updated docs re Opera screen-sharing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 screensharing-extensions
 ========================
 
-This project includes sample code for developing screen-sharing extensions for Opera and
-older versions of Chrome (71 and lower). These extensions allow you to use screen-sharing
+This project includes sample code for developing screen-sharing extensions for older versions
+of of Chrome (71 and lower) and Opera (58 and lower). These extensions allow you to use screen-sharing
 support in Opera and older versions of Chrome with the [OpenTok.js][1] library.
 
-**Important:** In Chrome 72+ and Firefox 52+, an extension (or whitelist listing) is no longer
+**Important:** In Chrome 72+, Firefox 52+, and Opera 59+, an extension (or whitelist listing) is no longer
 needed for screen sharing. The browser prompts the end user for access to the screen, as it would
-for access to the camera. The extension in this repo is only included to support Opera and
-older versions of Chrome.
+for access to the camera. The extension in this repo is only included to support
+older versions of Chrome and Opera.
 
 For more information, see:
 

--- a/chrome/ScreenSharing/README.md
+++ b/chrome/ScreenSharing/README.md
@@ -1,11 +1,12 @@
 Screen Sharing Extension for Opera and Chrome
 =============================================
 
-This extension allows you to use the screen sharing support in Chrome with the [OpenTok.js][ot] client library.
+This extension allows you to use the screen-sharing support in older versions of
+Chrome and Opera with the [OpenTok.js][ot] client library.
 
-**Important:** Chrome 72+ no longer requires an extension for screen sharing. The browser prompts
+**Important:** Chrome 72+ and Opera 59+ no longer require an extension for screen sharing. The browser prompts
 the end user for access to the screen, as it would for access to the camera. The extension in this
-repo is only included to support Opera and older versions of Chrome.
+repo is only included to support older versions of Chrome and Opera.
 
 This is a variation of [the extension][mkext] created by [Muaz Khan][mkgh] with some tweaks to make it more suitable for use with the OpenTok API.
 


### PR DESCRIPTION
As of Opera 59, and extension is no longer needed.